### PR TITLE
Propagate clicks in button_press_event handlers

### DIFF
--- a/src/Widgets/TrackAlbumRow.vala
+++ b/src/Widgets/TrackAlbumRow.vala
@@ -129,6 +129,8 @@ public class Widgets.TrackAlbumRow : Gtk.ListBoxRow {
                 activate_menu ();
                 return true;
             }
+            
+            return false;
         });
 
         options_button.clicked.connect (activate_menu);

--- a/src/Widgets/TrackRow.vala
+++ b/src/Widgets/TrackRow.vala
@@ -208,6 +208,8 @@ public class Widgets.TrackRow : Gtk.ListBoxRow {
                 activate_menu ();
                 return true;
             }
+            
+            return false;
         });
 
         options_button.clicked.connect (activate_menu);


### PR DESCRIPTION
This is the proper fix for #7 

The signal handler for `button_press_event` **must** return a `bool`. If it does not, the behaviour is undefined.