### PR TITLE
Add missing dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You'll need the following dependencies:
 * libgstreamer-plugins-base1.0-dev
 * libtagc0-dev
 * libsqlite3-dev
+* libsoup2.4-dev
 * libgranite-dev (>=0.5)
 * meson
 * valac >= 0.40.3


### PR DESCRIPTION
The libsoup2.4-dev dependency is needed too in order to build the app.