### PR TITLE
Updated deprecated radio browser api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You'll need the following dependencies:
 * libtagc0-dev
 * libsqlite3-dev
 * libsoup2.4-dev
+* libjson-glib-dev
 * libgranite-dev (>=0.5)
 * meson
 * valac >= 0.40.3

--- a/src/Services/RadioBrowser.vala
+++ b/src/Services/RadioBrowser.vala
@@ -8,7 +8,7 @@ public class Services.RadioBrowser : GLib.Object {
     public signal void finished ();
     public signal void item_loaded (Objects.Radio radio);
 
-    private string API_URL = "http://www.radio-browser.info/webservice/json/stations/byname/";
+    private string API_URL = "http://all.api.radio-browser.info/json/stations/byname/";
 
     public RadioBrowser () {
         session = new Soup.Session ();


### PR DESCRIPTION
Old api is deprecated and will be taken down at August 1. Also new stations are not showing because that service wasn't updating its lists.