### PR TITLE
Flatpak app manifest using elementary OS 6 SDK

### DIFF
--- a/com.github.alainm23.byte.yml
+++ b/com.github.alainm23.byte.yml
@@ -1,0 +1,44 @@
+app-id: com.github.alainm23.byte
+runtime: io.elementary.Platform
+runtime-version: 'daily' #change this to release version (currently 0.1.0) once they fix the lack of inherited GL extensions bug
+sdk: io.elementary.Sdk
+command: com.github.alainm23.byte
+finish-args:
+  - '--filesystem=host'
+
+  - '--socket=fallback-x11'
+  - '--socket=wayland'
+  - '--filesystem=xdg-run/dconf'
+  - '--talk-name=org.gnome.SettingsDaemon'
+  - '--talk-name=ca.desrt.dconf'
+  - '--env=DCONF_USER_CONFIG_DIR=.config/dconf'
+cleanup:
+  - '/include'
+  - '/lib/pkgconfig'
+  - '/man'
+  - '/share/gtk-doc'
+  - '/share/man'
+  - '/share/pkgconfig'
+  - '/share/vala'
+  - '*.a'
+  - '*.la'
+modules:
+
+  - name: taglib
+    buildsystem: cmake-ninja
+    config-opts:
+      - '-DBUILD_SHARED_LIBS=ON'
+    cleanup:
+      - /bin
+    sources:
+        - type: git
+          url: https://github.com/taglib/taglib.git
+          tag: v1.12
+
+  - name: byte
+    buildsystem: meson
+    config-opts:
+     - '--libdir=lib'
+    sources:
+      - type: dir
+        path: .

--- a/com.github.alainm23.byte.yml
+++ b/com.github.alainm23.byte.yml
@@ -4,11 +4,11 @@ runtime-version: 'daily' #change this to release version (currently 0.1.0) once 
 sdk: io.elementary.Sdk
 command: com.github.alainm23.byte
 finish-args:
-  - '--filesystem=host'
+  - '--filesystem=xdg-music'
 
   - '--socket=fallback-x11'
   - '--socket=wayland'
-  - '--filesystem=xdg-run/dconf'
+  - '--socket=pulseaudio'
   - '--talk-name=org.gnome.SettingsDaemon'
   - '--talk-name=ca.desrt.dconf'
   - '--env=DCONF_USER_CONFIG_DIR=.config/dconf'

--- a/data/com.github.alainm23.byte.appdata.xml.in
+++ b/data/com.github.alainm23.byte.appdata.xml.in
@@ -34,10 +34,12 @@
         </ul>
         <p>Special thanks to 'Eddie Vassallo' for becoming our new Gold Tier Patrons and supporting the development of Byte.</p>
         <p>🌟️ Thank you to our silver members for supporting the development of Byte. 🌟️</p>
-        <li>Cal</li>
-        <li>I Sutter</li>
-        <li>The Linux Experiment</li>
-        <li>Wout</li>
+        <ul>
+          <li>Cal</li>
+          <li>I Sutter</li>
+          <li>The Linux Experiment</li>
+          <li>Wout</li>
+        </ul>
       </description>
     </release>
 

--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -1,8 +1,8 @@
-@define-color colorPrimary #fe2851;
+@define-color color_primary #fe2851;
 @define-color textColorPrimary #ffffff;
 @define-color bg_color shade (@base_color, 0.98);
 
-@define-color colorAccent #fe2851;
+@define-color color_accent #fe2851;
 
 entry {
     caret-color: @colorAccent;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -130,9 +130,6 @@ public class Byte : Gtk.Application {
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         utils.apply_theme (Byte.settings.get_enum ("theme"));
-
-        Gtk.Settings.get_default().set_property("gtk-icon-theme-name", "elementary");
-        Gtk.Settings.get_default().set_property("gtk-theme-name", "elementary");
     }
 
     public override void open (File[] files, string hint) {


### PR DESCRIPTION
This PR adds the new manifest and fixes the appdata file missing the `<ul>` tags in the silver sponsor section (which otherwise cause the flatpak build to fail)
Note that this is using the `daily` SDK, which is available alongside the regular release on the elementary system flatpak repo