### PR TITLE
Save and restore the playing state when the app restarts

### DIFF
--- a/data/com.github.alainm23.byte.gschema.xml
+++ b/data/com.github.alainm23.byte.gschema.xml
@@ -130,6 +130,12 @@
 			<description>Type of queue that was used, to restore it after restart</description>
 		</key>
 		
+		<key name="queue-id" type="i">
+			<default>0</default>
+			<summary>Queue Type</summary>
+			<description>Type of queue that was used, to restore it after restart</description>
+		</key>
+		
 		<key name="window-position" type="(ii)">
 			<default>(-1, -1)</default>
 			<summary>Window position</summary>

--- a/data/com.github.alainm23.byte.gschema.xml
+++ b/data/com.github.alainm23.byte.gschema.xml
@@ -40,15 +40,26 @@
 		<value nick="Files" value="1" />
 	</enum>
 
-    <schema path="/com/github/alainm23/byte/" id="com.github.alainm23.byte" gettext-domain="com.github.alainm23.byte">
+	<enum id="com.github.alainm23.byte.queue-type">
+		<value nick="None" value="0" />
+		<value nick="RecentlyAdded" value="1" />
+		<value nick="Songs" value="2" />
+		<value nick="Playlist" value="3" />
+		<value nick="Album" value="4" />
+		<value nick="Artist" value="5" />
+		<value nick="Favorites" value="6" />
+		<value nick="Radio" value="7" />
+	</enum>
+
+	<schema path="/com/github/alainm23/byte/" id="com.github.alainm23.byte" gettext-domain="com.github.alainm23.byte">
 		<key name="theme" enum="com.github.alainm23.byte.theme">
-            <default>"Byte"</default>
-            <summary>Theme</summary>
-            <description>Theme</description>
-        </key>
+			<default>"Byte"</default>
+			<summary>Theme</summary>
+			<description>Theme</description>
+		</key>
 
 		<key name="library-location" type="s">
-		    <default>""</default>
+			<default>""</default>
 			<summary>Default library location.</summary>
 			<description>Default library location.</description>
 		</key>
@@ -101,10 +112,22 @@
 			<description>Album order reverse</description>
 		</key>
 
-        <key name="shuffle-mode" type="b">
+		<key name="shuffle-mode" type="b">
 			<default>false</default>
 			<summary>Shuffle mode</summary>
 			<description>Shuffle mode</description>
+		</key>
+
+		<key name="last-played" type="i">
+			<default>0</default>
+			<summary>Last track played</summary>
+			<description>ID of the last track that was played, to restore it after restart</description>
+		</key>
+		
+		<key name="queue-type" enum="com.github.alainm23.byte.queue-type">
+			<default>"None"</default>
+			<summary>Queue Type</summary>
+			<description>Type of queue that was used, to restore it after restart</description>
 		</key>
 		
 		<key name="window-position" type="(ii)">

--- a/data/com.github.alainm23.byte.gschema.xml
+++ b/data/com.github.alainm23.byte.gschema.xml
@@ -123,6 +123,12 @@
 			<summary>Last track played</summary>
 			<description>ID of the last track that was played, to restore it after restart</description>
 		</key>
+
+		<key name="track-progression" type="d">
+			<default>0.0</default>
+			<summary>Play progression</summary>
+			<description>Progression of the last track that was played, to restore it after restart</description>
+		</key>
 		
 		<key name="queue-type" enum="com.github.alainm23.byte.queue-type">
 			<default>"None"</default>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -208,39 +208,45 @@ public class MainWindow : Gtk.Window {
         int queue_type_id = Byte.settings.get_enum ("queue-type");
         int queue_id = Byte.settings.get_int ("queue-id");
         int last_played_id = Byte.settings.get_int ("last-played");
+        double track_progression = Byte.settings.get_double ("track-progression");
+
+        print ("restoring: %d, %d, %d, %f\n", queue_type_id, queue_id, last_played_id, track_progression);
 
         switch (queue_type_id) {
             case 1: // RecentlyAdded
                 print ("Restore playing recently added\n");
-                Byte.utils.play_queue_start_with_track_by_id (home_view.all_tracks, 1, last_played_id);
+                Byte.utils.play_queue_start_with_track_by_id (home_view.all_tracks, 1, last_played_id, track_progression);
                 break;
             case 2: // Songs
                 print ("Restore playing all songs\n");
                 var tracks_view = new Views.Tracks ();
-                Byte.utils.play_queue_start_with_track_by_id (tracks_view.all_tracks, 2, last_played_id);
+                Byte.utils.play_queue_start_with_track_by_id (tracks_view.all_tracks, 2, last_played_id, track_progression);
                 break;
             case 3: // Playlist
                 Objects.Playlist playlist = Byte.database.get_playlist_by_id (queue_id);
                 print ("Restoring last played playlist: %s\n", playlist.title);
                 var playlist_view = new Views.Playlist (playlist);
-                Byte.utils.play_queue_start_with_track_by_id (playlist_view.all_tracks, 3, last_played_id);
+                Byte.utils.play_queue_start_with_track_by_id (playlist_view.all_tracks, 3, last_played_id,
+                    track_progression, queue_id);
                 break;
             case 4: // Album
                 Objects.Album album = Byte.database.get_album_by_id (queue_id);
                 print ("Restoring last played album: %s\n", album.title);
                 var album_view = new Views.Album (album);
-                Byte.utils.play_queue_start_with_track_by_id (album_view.all_tracks, 4, last_played_id);
+                Byte.utils.play_queue_start_with_track_by_id (album_view.all_tracks, 4, last_played_id,
+                    track_progression, queue_id);
                 break;
             case 5: // Artist
                 Objects.Artist artist = Byte.database.get_artist_by_id (queue_id);
                 print ("Restoring last played artist: %s\n", artist.name);
                 var artist_view = new Views.Artist (artist);
-                Byte.utils.play_queue_start_with_track_by_id (artist_view.all_tracks, 5, last_played_id);
+                Byte.utils.play_queue_start_with_track_by_id (artist_view.all_tracks, 5, last_played_id,
+                    track_progression, queue_id);
                 break;
             case 6: // Favorites
                 print ("Restore playing favorites\n");
                 var favorites_view = new Views.Favorites ();
-                Byte.utils.play_queue_start_with_track_by_id (favorites_view.all_tracks, 6, last_played_id);
+                Byte.utils.play_queue_start_with_track_by_id (favorites_view.all_tracks, 6, last_played_id, track_progression);
                 break;
             //  case 7: // Radio
             //      break;
@@ -248,8 +254,8 @@ public class MainWindow : Gtk.Window {
                 if (last_played_id != 0) {
                     Objects.Track? last_played_track = Byte.database.get_track_by_id (last_played_id);
                     if (last_played_track != null) {
-                        print ("Restoring last played track: %s\n", last_played_track.title);
-                        Byte.player.set_track (last_played_track);
+                        print ("Restoring last played track: %s at %f%\n", last_played_track.title, track_progression);
+                        Byte.player.set_track (last_played_track, track_progression);
                     }
                 }
                 break;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -86,6 +86,15 @@ public class MainWindow : Gtk.Window {
                 main_stack.visible_child_name = "welcome_view";
                 headerbar.visible_ui = false;
             } else {
+                int last_played_id = Byte.settings.get_int ("last-played");
+                if (last_played_id != 0) {
+                    Objects.Track? last_played_track = Byte.database.get_track_by_id (last_played_id);
+                    if (last_played_track != null) {
+                        print ("Restoring last played track: %s\n", last_played_track.title);
+                        Byte.player.set_track (last_played_track);
+                    }
+                }
+
                 main_stack.visible_child_name = "library_view";
 
                 Byte.navCtrl.go_root ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -86,14 +86,7 @@ public class MainWindow : Gtk.Window {
                 main_stack.visible_child_name = "welcome_view";
                 headerbar.visible_ui = false;
             } else {
-                int last_played_id = Byte.settings.get_int ("last-played");
-                if (last_played_id != 0) {
-                    Objects.Track? last_played_track = Byte.database.get_track_by_id (last_played_id);
-                    if (last_played_track != null) {
-                        print ("Restoring last played track: %s\n", last_played_track.title);
-                        Byte.player.set_track (last_played_track);
-                    }
-                }
+                restore_playing_state ();
 
                 main_stack.visible_child_name = "library_view";
 
@@ -206,5 +199,60 @@ public class MainWindow : Gtk.Window {
         });
 
         return base.configure_event (event);
+    }
+
+    /**
+     * Restore last playing state
+     */
+    private void restore_playing_state () {
+        int queue_type_id = Byte.settings.get_enum ("queue-type");
+        int queue_id = Byte.settings.get_int ("queue-id");
+        int last_played_id = Byte.settings.get_int ("last-played");
+
+        switch (queue_type_id) {
+            case 1: // RecentlyAdded
+                print ("Restore playing recently added\n");
+                Byte.utils.play_queue_start_with_track_by_id (home_view.all_tracks, 1, last_played_id);
+                break;
+            case 2: // Songs
+                print ("Restore playing all songs\n");
+                var tracks_view = new Views.Tracks ();
+                Byte.utils.play_queue_start_with_track_by_id (tracks_view.all_tracks, 2, last_played_id);
+                break;
+            case 3: // Playlist
+                Objects.Playlist playlist = Byte.database.get_playlist_by_id (queue_id);
+                print ("Restoring last played playlist: %s\n", playlist.title);
+                var playlist_view = new Views.Playlist (playlist);
+                Byte.utils.play_queue_start_with_track_by_id (playlist_view.all_tracks, 3, last_played_id);
+                break;
+            case 4: // Album
+                Objects.Album album = Byte.database.get_album_by_id (queue_id);
+                print ("Restoring last played album: %s\n", album.title);
+                var album_view = new Views.Album (album);
+                Byte.utils.play_queue_start_with_track_by_id (album_view.all_tracks, 4, last_played_id);
+                break;
+            case 5: // Artist
+                Objects.Artist artist = Byte.database.get_artist_by_id (queue_id);
+                print ("Restoring last played artist: %s\n", artist.name);
+                var artist_view = new Views.Artist (artist);
+                Byte.utils.play_queue_start_with_track_by_id (artist_view.all_tracks, 5, last_played_id);
+                break;
+            case 6: // Favorites
+                print ("Restore playing favorites\n");
+                var favorites_view = new Views.Favorites ();
+                Byte.utils.play_queue_start_with_track_by_id (favorites_view.all_tracks, 6, last_played_id);
+                break;
+            //  case 7: // Radio
+            //      break;
+            default: // None
+                if (last_played_id != 0) {
+                    Objects.Track? last_played_track = Byte.database.get_track_by_id (last_played_id);
+                    if (last_played_track != null) {
+                        print ("Restoring last played track: %s\n", last_played_track.title);
+                        Byte.player.set_track (last_played_track);
+                    }
+                }
+                break;
+        }
     }
 }

--- a/src/Services/Database.vala
+++ b/src/Services/Database.vala
@@ -488,14 +488,15 @@ public class Services.Database : GLib.Object {
         Sqlite.Statement stmt;
         int res;
 
-        string sql = """
-            SELECT tracks.id, tracks.path, tracks.title, tracks.duration, tracks.is_favorite, tracks.track, tracks.date_added, 
-            tracks.play_count, tracks.album_id, albums.title, artists.id, artists.name, tracks.favorite_added, tracks.last_played FROM tracks 
-            INNER JOIN albums ON tracks.album_id = albums.id
-            INNER JOIN artists ON albums.artist_id = artists.id WHERE id = ?;
+        string sql_track = """
+            SELECT tracks.id, tracks.path, tracks.title, tracks.duration, tracks.is_favorite, tracks.track,
+                   tracks.date_added, tracks.play_count, tracks.favorite_added, tracks.last_played,
+                   tracks.album_id, tracks.album_artist
+            FROM tracks 
+            WHERE id = ?
         """;
 
-        res = db.prepare_v2 (sql, -1, out stmt);
+        res = db.prepare_v2 (sql_track, -1, out stmt);
         assert (res == Sqlite.OK);
 
         res = stmt.bind_int (1, id);
@@ -512,12 +513,26 @@ public class Services.Database : GLib.Object {
             track.track = stmt.column_int (5);
             track.date_added = stmt.column_text (6);
             track.play_count = stmt.column_int (7);
-            track.album_id = stmt.column_int (8);
-            track.album_title = stmt.column_text (9);
-            track.artist_id = stmt.column_int (10);
+            track.favorite_added = stmt.column_text (8);
+            track.last_played = stmt.column_text (9);
+            track.album_id = stmt.column_int (10);
+            // Artist name is retrieved from the Track, not the Artist of the Album
             track.artist_name = stmt.column_text (11);
-            track.favorite_added = stmt.column_text (12);
-            track.last_played = stmt.column_text (13);
+
+            if (track.album_id != 0) {
+                string sql_album = "SELECT albums.title, albums.artist_id FROM albums WHERE id = ?";
+
+                res = db.prepare_v2 (sql_album, -1, out stmt);
+                assert (res == Sqlite.OK);
+
+                res = stmt.bind_int (1, track.album_id);
+                assert (res == Sqlite.OK);
+
+                if (stmt.step () == Sqlite.ROW) {
+                    track.album_title = stmt.column_text (0);
+                    track.artist_id = stmt.column_int (1);
+                }
+            }
         }
 
         return track;

--- a/src/Services/Player.vala
+++ b/src/Services/Player.vala
@@ -120,26 +120,37 @@ public class Services.Player : GLib.Object {
         play ();
     }
 
-    public void set_track (Objects.Track? track) {
+    public void set_track (Objects.Track? track, double progress = 0) {
         if (track == null) {
             current_duration_changed (0);
         }
 
-        if (load_track (track)) {
+        if (load_track (track, progress)) {
             current_track_changed (track);
             mode_changed ("track");
             mode = "track";
 
             play ();
+        } else {
+            next ();
         }
     }
 
-    public bool load_track (Objects.Track? track, double progress = 0) {
+    public bool load_track (Objects.Track? track, double progress) {
         if (track == current_track || track == null) {
             return false;
         }
+        print ("loading track: %s\n", track.title);
 
         current_track = track;
+
+        // Skip current track if the file is not found
+        // TODO ajouter une notification d'avertissement
+        File song_file = File.new_for_uri (track.path);
+        if (!song_file.query_exists ()) {
+            print ("File not found: %s\n", track.path);
+            return false;
+        }
         
         var last_state = get_state ();
         stop ();
@@ -149,7 +160,7 @@ public class Services.Player : GLib.Object {
         state_changed (Gst.State.PLAYING);
         player_state = Gst.State.PLAYING;
 
-        while (duration == 0) {};
+        while (duration == 0 || duration == -1) {};
 
         if (last_state != Gst.State.PLAYING) {
             pause ();
@@ -157,7 +168,7 @@ public class Services.Player : GLib.Object {
 
         current_duration_changed (duration);
 
-        if (progress > 0) {
+        if (progress > 0.0) {
             seek_to_progress (progress);
             current_progress_changed (progress);
         }
@@ -199,7 +210,7 @@ public class Services.Player : GLib.Object {
     public void stop_progress_signal (bool reset_timer = false) {
         pause_progress_signal ();
         if (reset_timer) {
-            current_progress_changed (0);
+            current_progress_changed (0.0);
         }
     }
 

--- a/src/Services/TagManager.vala
+++ b/src/Services/TagManager.vala
@@ -19,6 +19,7 @@ public class Services.TagManager : GLib.Object {
 
             if (info.get_result () != Gst.PbUtils.DiscovererResult.OK) {
                 if (err != null) {
+                    // Printing err.message often triggers Segmentation fault for some reason
                     warning ("DISCOVER ERROR: '%d' %s %s\n(%s)", err.code, err.message, info.get_result ().to_string (), uri);
                 }
             } else {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -1,7 +1,7 @@
 public class Utils : GLib.Object {
     public Gee.ArrayList<Objects.Track?> queue_playlist { set; get; }
 
-    public signal void play_items (Gee.ArrayList<Objects.Track?> items, Objects.Track? track);
+    public signal void play_items (Gee.ArrayList<Objects.Track?> items, Objects.Track? track, int queue_type, int queue_id);
 
     public signal void update_next_track ();
     public signal void add_next_track (Gee.ArrayList<Objects.Track?> items);
@@ -27,7 +27,9 @@ public class Utils : GLib.Object {
         COVER_FOLDER = GLib.Path.build_filename (MAIN_FOLDER, "covers");
     }
 
-    public void set_items (Gee.ArrayList<Objects.Track?> all_items, bool shuffle_mode, Objects.Track? track) {
+    public void set_items (Gee.ArrayList<Objects.Track?> all_items, bool shuffle_mode, Objects.Track? track,
+        int queue_type = 0, int queue_id = 0
+    ) {
         if (all_items.size > 0) {
             if (shuffle_mode) {
                 queue_playlist = generate_shuffle (all_items);
@@ -44,7 +46,7 @@ public class Utils : GLib.Object {
                 Byte.settings.set_boolean ("shuffle-mode", false);
             }
 
-            play_items (queue_playlist, track);
+            play_items (queue_playlist, track, queue_type, queue_id);
         }
     }
 
@@ -62,7 +64,7 @@ public class Utils : GLib.Object {
                 queue_playlist = playlist_order (queue_playlist);
             }
 
-            play_items (queue_playlist, Byte.player.current_track);
+            play_items (queue_playlist, Byte.player.current_track, -1, -1);
             update_next_track ();
         }
     }
@@ -370,5 +372,40 @@ public class Utils : GLib.Object {
         } catch (GLib.Error e) {
             return;
         }
+    }
+    public void play_queue_start_with_track_by_id (Gee.ArrayList<Objects.Track?> tracks, int queue_type, int track_id) {
+        Objects.Track? track = find_track (tracks, track_id);
+
+        if (track == null) play_queue (tracks, queue_type, Byte.settings.get_boolean ("shuffle-mode"));
+        else play_queue_start_with_track (tracks, queue_type, track);
+    }
+
+    public void play_queue_start_with_track (Gee.ArrayList<Objects.Track?> tracks, int queue_type, Objects.Track track) {
+        Byte.utils.set_items (
+            tracks,
+            Byte.settings.get_boolean ("shuffle-mode"),
+            track,
+            queue_type
+        );
+    }
+
+    public void play_queue (Gee.ArrayList<Objects.Track?> tracks, int queue_type, bool shuffled) {
+        Byte.utils.set_items (
+            tracks,
+            shuffled,
+            null,
+            queue_type
+        );
+    }
+
+    private Objects.Track? find_track (Gee.ArrayList<Objects.Track?> tracks, int track_id) {
+        var it = tracks.iterator ();
+        for (var has_next = it.next (); has_next; has_next = it.next ()) {
+            if (it.get () != null && it.get ().id == track_id) {
+                return it.get ();
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -1,7 +1,8 @@
 public class Utils : GLib.Object {
     public Gee.ArrayList<Objects.Track?> queue_playlist { set; get; }
 
-    public signal void play_items (Gee.ArrayList<Objects.Track?> items, Objects.Track? track, int queue_type, int queue_id);
+    public signal void play_items (Gee.ArrayList<Objects.Track?> items, Objects.Track? track, int queue_type,
+        int queue_id, double progress);
 
     public signal void update_next_track ();
     public signal void add_next_track (Gee.ArrayList<Objects.Track?> items);
@@ -28,7 +29,7 @@ public class Utils : GLib.Object {
     }
 
     public void set_items (Gee.ArrayList<Objects.Track?> all_items, bool shuffle_mode, Objects.Track? track,
-        int queue_type = 0, int queue_id = 0
+        int queue_type = 0, double progress = 0, int queue_id = 0
     ) {
         if (all_items.size > 0) {
             if (shuffle_mode) {
@@ -46,7 +47,7 @@ public class Utils : GLib.Object {
                 Byte.settings.set_boolean ("shuffle-mode", false);
             }
 
-            play_items (queue_playlist, track, queue_type, queue_id);
+            play_items (queue_playlist, track, queue_type, queue_id, progress);
         }
     }
 
@@ -64,7 +65,7 @@ public class Utils : GLib.Object {
                 queue_playlist = playlist_order (queue_playlist);
             }
 
-            play_items (queue_playlist, Byte.player.current_track, -1, -1);
+            play_items (queue_playlist, Byte.player.current_track, -1, -1, 0.0);
             update_next_track ();
         }
     }
@@ -373,28 +374,37 @@ public class Utils : GLib.Object {
             return;
         }
     }
-    public void play_queue_start_with_track_by_id (Gee.ArrayList<Objects.Track?> tracks, int queue_type, int track_id) {
+
+    public void play_queue_start_with_track_by_id (Gee.ArrayList<Objects.Track?> tracks, int queue_type,
+        int track_id, double progress, int queue_id = 0
+    ) {
         Objects.Track? track = find_track (tracks, track_id);
 
         if (track == null) play_queue (tracks, queue_type, Byte.settings.get_boolean ("shuffle-mode"));
-        else play_queue_start_with_track (tracks, queue_type, track);
+        else play_queue_start_with_track (tracks, queue_type, track, progress, queue_id);
     }
 
-    public void play_queue_start_with_track (Gee.ArrayList<Objects.Track?> tracks, int queue_type, Objects.Track track) {
-        Byte.utils.set_items (
+    public void play_queue_start_with_track (Gee.ArrayList<Objects.Track?> tracks, int queue_type, Objects.Track track,
+        double progress = 0, int queue_id = 0
+    ) {
+        set_items (
             tracks,
             Byte.settings.get_boolean ("shuffle-mode"),
             track,
-            queue_type
+            queue_type,
+            progress,
+            queue_id
         );
     }
 
-    public void play_queue (Gee.ArrayList<Objects.Track?> tracks, int queue_type, bool shuffled) {
-        Byte.utils.set_items (
+    public void play_queue (Gee.ArrayList<Objects.Track?> tracks, int queue_type, bool shuffled, int queue_id = 0) {
+        set_items (
             tracks,
             shuffled,
             null,
-            queue_type
+            queue_type,
+            0,
+            queue_id
         );
     }
 

--- a/src/Views/Album.vala
+++ b/src/Views/Album.vala
@@ -169,7 +169,7 @@ public class Views.Album : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackAlbumRow;
             
-            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track, 0, album.id);
         });
 
         play_button.clicked.connect (() => {

--- a/src/Views/Album.vala
+++ b/src/Views/Album.vala
@@ -1,4 +1,6 @@
 public class Views.Album : Gtk.EventBox {
+    private static int QUEUE_TYPE = 4;
+
     public Objects.Album album { get; construct; }
 
     private Gtk.Label title_label;
@@ -11,7 +13,7 @@ public class Views.Album : Gtk.EventBox {
     private string cover_path;
     private Widgets.Cover image_cover;
     
-    private Gee.ArrayList<Objects.Track?> all_tracks;
+    public Gee.ArrayList<Objects.Track?> all_tracks;
 
     public Album (Objects.Album album) {
         Object (
@@ -167,27 +169,15 @@ public class Views.Album : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackAlbumRow;
             
-            Byte.utils.set_items (
-                all_tracks,
-                Byte.settings.get_boolean ("shuffle-mode"),
-                item.track
-            );
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
         });
 
         play_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                false,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE, false);
         });
 
         shuffle_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                true,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE, true);
         });
 
         Byte.database.adden_new_track.connect ((track) => {
@@ -229,4 +219,4 @@ public class Views.Album : Gtk.EventBox {
             });
         });
     }
-}
+}   

--- a/src/Views/Artist.vala
+++ b/src/Views/Artist.vala
@@ -1,4 +1,6 @@
 public class Views.Artist : Gtk.EventBox {
+    private static int QUEUE_TYPE = 5;
+
     public Objects.Artist artist { get; construct; }
 
     private Gtk.Label name_label;
@@ -6,7 +8,7 @@ public class Views.Artist : Gtk.EventBox {
     private Gtk.ListBox listbox;
     private Gtk.FlowBox flowbox;
 
-    private Gee.ArrayList<Objects.Track?> all_tracks;
+    public Gee.ArrayList<Objects.Track?> all_tracks;
     private Gee.ArrayList<Objects.Album?> all_albums;
 
     public Artist (Objects.Artist artist) {
@@ -148,11 +150,7 @@ public class Views.Artist : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
             
-            Byte.utils.set_items (
-                all_tracks,
-                Byte.settings.get_boolean ("shuffle-mode"),
-                item.track
-            );
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
         });
 
         flowbox.child_activated.connect ((child) => {

--- a/src/Views/Artist.vala
+++ b/src/Views/Artist.vala
@@ -150,7 +150,7 @@ public class Views.Artist : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
             
-            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track, 0, artist.id);
         });
 
         flowbox.child_activated.connect ((child) => {

--- a/src/Views/Favorites.vala
+++ b/src/Views/Favorites.vala
@@ -1,9 +1,12 @@
 public class Views.Favorites : Gtk.EventBox {
+    private static int QUEUE_TYPE = 6;
+
     private Gtk.ListBox listbox;
     public signal void go_back ();
+
     private int item_index;
     private int item_max;
-    private Gee.ArrayList<Objects.Track?> all_tracks;
+    public Gee.ArrayList<Objects.Track?> all_tracks;
 
     public Favorites () {} 
 
@@ -183,29 +186,17 @@ public class Views.Favorites : Gtk.EventBox {
         });
 
         play_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                false,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE,false);
         });
 
         shuffle_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                true,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE,true);
         });
 
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
             
-            Byte.utils.set_items (
-                all_tracks,
-                Byte.settings.get_boolean ("shuffle-mode"),
-                item.track
-            );
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
         });
 
         scrolled.edge_reached.connect((pos)=> {

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -1,6 +1,8 @@
 public class Views.Home : Gtk.EventBox {
+    private static int QUEUE_TYPE = 1;
+
     private Gtk.ListBox listbox;
-    private Gee.ArrayList<Objects.Track?> all_tracks;
+    public Gee.ArrayList<Objects.Track?> all_tracks;
     
     construct {
         get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
@@ -126,11 +128,7 @@ public class Views.Home : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
             
-            Byte.utils.set_items (
-                all_tracks,
-                Byte.settings.get_boolean ("shuffle-mode"),
-                item.track
-            );
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
         });
 
         Byte.database.adden_new_track.connect ((track) => {

--- a/src/Views/Playlist.vala
+++ b/src/Views/Playlist.vala
@@ -1,4 +1,6 @@
 public class Views.Playlist : Gtk.EventBox {
+    private static int QUEUE_TYPE = 3;
+
     public Objects.Playlist playlist { get; construct; }
     public Gtk.Entry title_entry;
     private Gtk.TextView note_text;
@@ -15,7 +17,7 @@ public class Views.Playlist : Gtk.EventBox {
     private string cover_path;
     private Widgets.Cover image_cover;
 
-    private Gee.ArrayList<Objects.Track?> all_tracks;
+    public Gee.ArrayList<Objects.Track?> all_tracks;
 
     public Playlist (Objects.Playlist playlist) {
         Object (
@@ -290,27 +292,15 @@ public class Views.Playlist : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
 
-            Byte.utils.set_items (
-                all_tracks,
-                Byte.settings.get_boolean ("shuffle-mode"),
-                item.track
-            );
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
         });
 
         play_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                false,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE, false);
         });
 
         shuffle_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                true,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE, true);
         });
 
         sort_button.toggled.connect (() => {

--- a/src/Views/Playlist.vala
+++ b/src/Views/Playlist.vala
@@ -292,7 +292,7 @@ public class Views.Playlist : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
 
-            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track, 0, playlist.id);
         });
 
         play_button.clicked.connect (() => {

--- a/src/Views/Tracks.vala
+++ b/src/Views/Tracks.vala
@@ -1,4 +1,6 @@
 public class Views.Tracks : Gtk.EventBox {
+    private static int QUEUE_TYPE = 2;
+
     private Widgets.SearchEntry search_entry;
     private Gtk.ListBox listbox;
 
@@ -8,7 +10,7 @@ public class Views.Tracks : Gtk.EventBox {
 
     private int item_index;
     private int item_max;
-    private Gee.ArrayList<Objects.Track?> all_tracks;
+    public Gee.ArrayList<Objects.Track?> all_tracks;
 
     construct {
         item_index = 0;
@@ -227,29 +229,17 @@ public class Views.Tracks : Gtk.EventBox {
         });
 
         play_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                false,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE, false);
         });
 
         shuffle_button.clicked.connect (() => {
-            Byte.utils.set_items (
-                all_tracks,
-                true,
-                null
-            );
+            Byte.utils.play_queue (all_tracks, QUEUE_TYPE, true);
         });
 
         listbox.row_activated.connect ((row) => {
             var item = row as Widgets.TrackRow;
             
-            Byte.utils.set_items (
-                all_tracks,
-                Byte.settings.get_boolean ("shuffle-mode"),
-                item.track
-            );
+            Byte.utils.play_queue_start_with_track (all_tracks, QUEUE_TYPE, item.track);
         });
 
         listbox_scrolled.edge_reached.connect ((pos)=> {

--- a/src/Widgets/MediaControl.vala
+++ b/src/Widgets/MediaControl.vala
@@ -102,6 +102,11 @@ public class Widgets.MediaControl : Gtk.Revealer {
             if (timeline.playback_duration == 0) {
                 timeline.playback_duration = Byte.player.duration / Gst.SECOND;
             }
+            // Save progress only every two seconds to reduce disk writes
+            int int_progress = (int)(progress * 100);
+            if (progress >= 0.0 && progress <= 0.99 && int_progress % 2 == 1) {
+                Byte.settings.set_double ("track-progression", progress);
+            }
         });
 
         Byte.player.current_duration_changed.connect ((duration) => {

--- a/src/Widgets/Queue.vala
+++ b/src/Widgets/Queue.vala
@@ -196,7 +196,7 @@ public class Widgets.Queue : Gtk.Revealer {
 
         add (main_box);
 
-        Byte.utils.play_items.connect ((_items, _track, queue_type, queue_id) => {
+        Byte.utils.play_items.connect ((_items, _track, queue_type, queue_id, progress) => {
             listbox.foreach ((widget) => {
                 widget.destroy ();
             });
@@ -220,7 +220,7 @@ public class Widgets.Queue : Gtk.Revealer {
             if (_track == null) {
                 Byte.player.set_track (items [0]);
             } else {
-                Byte.player.set_track (_track);
+                Byte.player.set_track (_track, progress);
 
                 int current_index = Byte.utils.get_track_index_by_id (_track.id, items);
 

--- a/src/Widgets/Queue.vala
+++ b/src/Widgets/Queue.vala
@@ -234,6 +234,8 @@ public class Widgets.Queue : Gtk.Revealer {
         });
 
         Byte.player.current_track_changed.connect ((track) => {
+            Byte.settings.set_int ("last-played", track.id);
+
             int current_index = Byte.utils.get_track_index_by_id (track.id, items);
 
             listbox.set_filter_func ((row) => {

--- a/src/Widgets/Queue.vala
+++ b/src/Widgets/Queue.vala
@@ -196,7 +196,7 @@ public class Widgets.Queue : Gtk.Revealer {
 
         add (main_box);
 
-        Byte.utils.play_items.connect ((_items, _track) => {
+        Byte.utils.play_items.connect ((_items, _track, queue_type, queue_id) => {
             listbox.foreach ((widget) => {
                 widget.destroy ();
             });
@@ -211,6 +211,11 @@ public class Widgets.Queue : Gtk.Revealer {
             }
 
             add_all_items (items);
+        
+            if (queue_type != -1) {
+                Byte.settings.set_enum ("queue-type", queue_type);
+                Byte.settings.set_int ("queue-id", queue_id);   
+            }
 
             if (_track == null) {
                 Byte.player.set_track (items [0]);


### PR DESCRIPTION
Add new settings where current track and queue information (type and id of playlist) are stored : last-played, queue-type, queue-id, track-progression.
Those data are stored when the track or queue changes, and when the current playing track progression changes (every two seconds).
When the application starts, the saved data are read and the current queue, track played and progression are restored. Next track information is not stored, so when "shuffle" is used, the next tracks of the playlist are shuffled again.

- I did not implement restoring from Radio
- When a track is not found, we now read the next one instead of stopping playback.
- Also fixes the database method `get_track_by_id` to retrieve the Artist name from the Track, not the Artist of the Album. It could lead to errors.